### PR TITLE
增加对mybatis-spring-boot-starter 2.x版本插入不返回主键的兼容

### DIFF
--- a/Chapter 3/mybatis-demo/src/main/java/geektime/spring/data/mybatisdemo/mapper/CoffeeMapper.java
+++ b/Chapter 3/mybatis-demo/src/main/java/geektime/spring/data/mybatisdemo/mapper/CoffeeMapper.java
@@ -13,7 +13,7 @@ import org.apache.ibatis.annotations.Select;
 public interface CoffeeMapper {
     @Insert("insert into t_coffee (name, price, create_time, update_time)"
             + "values (#{name}, #{price}, now(), now())")
-    @Options(useGeneratedKeys = true)
+    @Options(useGeneratedKeys = true, keyProperty = "id")
     int save(Coffee coffee);
 
     @Select("select * from t_coffee where id = #{id}")


### PR DESCRIPTION
增加对mybatis-spring-boot-starter 2.x版本插入不返回主键的兼容，课程使用的版本无需添加keyProperty = "id"的配置，但新版本需要